### PR TITLE
Play by a specific "video id"

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ Play one of the svt channels.
   data:
     channel: svt1 # Available channels: svt1, svt2, svtbarn, kunskapskanalen, svt24
 ```
+### Play video id
+If a specific video should be played, its "id" can be extracted from the url. For example `jXvZLoG` is the id found in the following url:  `https://www.svtplay.se/video/jXvZLoG/ifs-invandrare-for-svenskar/avsnitt-3`
+```yaml
+- service: svt_play.play_videoid
+  entity_id: media_player.living_room_tv
+  data:
+    videoid: jXvZLoG
+```
 
 ## Installation
 

--- a/custom_components/svt_play/services.yaml
+++ b/custom_components/svt_play/services.yaml
@@ -31,3 +31,12 @@ play_channel:
     entity_id:
       description: Name(s) of entities to play on.
       example: "media_player.living_room_chromecast"
+play_videoid:
+  description: Play the specified video id
+  fields:
+    videoid:
+      description: The id of the video.
+      example: "jXvZLoG"
+    entity_id:
+      description: Name(s) of entities to play on.
+      example: "media_player.living_room_chromecast"

--- a/info.md
+++ b/info.md
@@ -17,12 +17,23 @@ Play the suggested video that is shown on svtplay.se. This is the recomended way
 
 ### Play Latest
 Play the latest video or clip from a specific program. There exists two options to exclude or include videos matching specific categories.
+```yaml
 - service: svt_play.play_latest
   entity_id: media_player.living_room_tv
   data:
     program_name: skavlan
     category: Intervjuer # Optional
     exclude_category: utan filmer # Optional
+```
+
+### Play random
+Play a random video or clip from a specific program. There exist an option to just random from specific categories.
+```yaml
+- service: svt_play.play_random
+  entity_id: media_player.living_room_tv
+  data:
+    program_name: skavlan
+    category: Intervjuer # Optional
 ```
 
 ### Play Channel
@@ -32,6 +43,14 @@ Play one of the svt channels.
   entity_id: media_player.living_room_tv
   data:
     channel: svt1 # Available channels: svt1, svt2, svtbarn, kunskapskanalen, svt24
+```
+### Play video id
+If a specific video should be played, its "id" can be extracted from the url. For example `jXvZLoG` is the id found in the following url:  `https://www.svtplay.se/video/jXvZLoG/ifs-invandrare-for-svenskar/avsnitt-3`
+```yaml
+- service: svt_play.play_videoid
+  entity_id: media_player.living_room_tv
+  data:
+    videoid: jXvZLoG
 ```
 
 ## Installation


### PR DESCRIPTION
By this PR, an additional service is exposed which allows users to a play a specific video by passing the "video id" found in the urls.

It is useful for automations/NFC tags/buttons that are used by children where a specific video is requested. 